### PR TITLE
Opencl stub fixes for psyclone

### DIFF
--- a/finite_difference/src/Makefile
+++ b/finite_difference/src/Makefile
@@ -103,7 +103,8 @@ all: ${API_LIB}
 # archive but take care to exclude clfortran.o (as that only has
 # interface definitions, not implementation).
 ${API_LIB}: fortcl ${MODULES}
-	${AR} ${ARFLAGS} ${API_LIB} ${MODULES}
+	${AR} ${ARFLAGS} ${API_LIB} *.o
+	${AR} d ${API_LIB} clfortran.o
 
 fortcl:
 	${MAKE} -f ${FORTCL_DIR}/Makefile F90=${F90} ${FORTCL_TARGET}

--- a/finite_difference/src/Makefile
+++ b/finite_difference/src/Makefile
@@ -107,7 +107,7 @@ ${API_LIB}: fortcl ${MODULES}
 	${AR} d ${API_LIB} clfortran.o
 
 fortcl:
-	${MAKE} -C ${FORTCL_DIR} F90=${F90} ${FORTCL_TARGET}
+	${MAKE} -f ${FORTCL_DIR}/Makefile F90=${F90} ${FORTCL_TARGET}
 
 install:
 	${MAKE} -C .. install

--- a/finite_difference/src/Makefile
+++ b/finite_difference/src/Makefile
@@ -103,8 +103,7 @@ all: ${API_LIB}
 # archive but take care to exclude clfortran.o (as that only has
 # interface definitions, not implementation).
 ${API_LIB}: fortcl ${MODULES}
-	${AR} ${ARFLAGS} ${API_LIB} ${FORTCL_DIR}/*.o ${MODULES}
-	${AR} d ${API_LIB} clfortran.o
+	${AR} ${ARFLAGS} ${API_LIB} ${MODULES}
 
 fortcl:
 	${MAKE} -f ${FORTCL_DIR}/Makefile F90=${F90} ${FORTCL_TARGET}

--- a/finite_difference/src/field_mod.f90
+++ b/finite_difference/src/field_mod.f90
@@ -72,7 +72,8 @@ module field_mod
      logical :: data_on_device
 
      ! TODO: For OpenCL compilation tests in PSyclone we need a device_ptr
-     ! here. Till full support for OpenCL is woring, provide a dummy variable:
+     ! here (see #10). Till full support for OpenCL is woring, provide a
+     ! dummy variable:
      integer*8 :: device_ptr
   end type field_type
 

--- a/finite_difference/src/field_mod.f90
+++ b/finite_difference/src/field_mod.f90
@@ -70,6 +70,10 @@ module field_mod
      !> Whether the data for this field lives in a remote memory space
      !! (e.g. on a GPU)
      logical :: data_on_device
+
+     ! TODO: For OpenCL compilation tests in PSyclone we need a device_ptr
+     ! here. Till full support for OpenCL is woring, provide a dummy variable:
+     integer*8 :: device_ptr
   end type field_type
 
   !> A real, 2D field.

--- a/finite_difference/src/grid_mod.f90
+++ b/finite_difference/src/grid_mod.f90
@@ -104,7 +104,8 @@ module grid_mod
      real(go_wp), allocatable :: xt(:,:), yt(:,:)
 
      ! TODO: For OpenCL compilation tests in PSyclone we need a device_ptr
-     ! here. Till full support for OpenCL is woring, provide a dummy variable:
+     ! here (see #10). Till full support for OpenCL is woring, provide a
+     ! dummy variable:
      integer*8 :: tmask_device
 
    contains

--- a/finite_difference/src/grid_mod.f90
+++ b/finite_difference/src/grid_mod.f90
@@ -102,6 +102,11 @@ module grid_mod
 
      !> Coordinates of grid (T) points in horizontal plane
      real(go_wp), allocatable :: xt(:,:), yt(:,:)
+
+     ! TODO: For OpenCL compilation tests in PSyclone we need a device_ptr
+     ! here. Till full support for OpenCL is woring, provide a dummy variable:
+     integer*8 :: tmask_device
+
    contains
      procedure :: get_tmask
 


### PR DESCRIPTION
Some minor changes:
- updated FortCL version in dl_esm_inf
- Updated Makefile to build fortcl in same directory as dl_esm_inf
- Added some dummy variables to grid and field which PSyclone created code accesses, so for PSyclone compile tests to work those variables must be declared.