### PR TITLE
Added DIST_MEM checks on map_comms subroutine

### DIFF
--- a/finite_difference/src/grid_mod.f90
+++ b/finite_difference/src/grid_mod.f90
@@ -273,6 +273,7 @@ contains
     use global_parameters_mod, only: ALIGNMENT
     use decomposition_mod, only: subdomain_type, decomposition_type
     use parallel_mod, only: map_comms, get_rank, get_num_ranks
+    use parallel_utils_mod, only: DIST_MEM_ENABLED
     implicit none
     type(grid_type), intent(inout) :: grid
     real(go_wp),              intent(in) :: dxarg, dyarg
@@ -458,8 +459,9 @@ contains
     end do
 
     !> Set-up the communication tables for halo exchanges
-    if( grid%boundary_conditions(1) == GO_BC_PERIODIC .or. &
-        grid%boundary_conditions(2) == GO_BC_PERIODIC )then
+    if( DIST_MEM_ENABLED .and. ( &
+        grid%boundary_conditions(1) == GO_BC_PERIODIC .or. &
+        grid%boundary_conditions(2) == GO_BC_PERIODIC) )then
        call gocean_stop('map_comms call needs to be implemented for ' &
                    &  //'periodic boundary conditions.')
     end if

--- a/finite_difference/src/parallel_comms_mod.f90
+++ b/finite_difference/src/parallel_comms_mod.f90
@@ -183,6 +183,7 @@ contains
     !     Mike Ashworth, CLRC Daresbury Laboratory, July 1999
     !     Andy Porter, STFC Daresbury Laboratory, March 2019
     !!------------------------------------------------------------------
+    use parallel_utils_mod, only: DIST_MEM_ENABLED
     implicit none
 
     ! Subroutine arguments.
@@ -210,6 +211,9 @@ contains
     logical :: addcorner
     integer :: nprocp, irank
     type(subdomain_type), pointer :: subdomain
+
+    ! Do nothing if distributed-memory support is not enabled
+    if(.not. DIST_MEM_ENABLED) return
 
     halo_depthx = halo_depths(1)
     halo_depthy = halo_depths(2)
@@ -1541,7 +1545,7 @@ contains
     !!--------------------------------------------------------------------
 
     ! Do nothing if distributed-memory support is not enabled
-    if(.not. DIST_MEM_ENABLED)return
+    if(.not. DIST_MEM_ENABLED) return
     
     ierr = 0
 


### PR DESCRIPTION
Allows PSycloneBench/ocean/shallow/SEQ to work when distributed memory is not enabled.