### PR TITLE
Make alignment configurable at runtime and improve distributed memory output

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ the latter you will of course need MPI installed.
 The `finite_difference/example` directory contains a very simple example
 of how to construct a model grid and associate fields with it.
 
+## Runtime configuration ##
+
+The following environment variables can be set up to tune runtime options:
+
+- ALIGNMENT: Positive integer that specifies a value by which the grid contiguous
+dimension length should be divisible. If that is not the case for the selected
+problem dimensions, it will add padding elements in that dimension until the
+condition holds true. If not specified it defaults to 1.
+
 ## Documentation ##
 
 The documentation is in the top-level `doc` directory and can be built
@@ -41,10 +50,6 @@ working Python installation with sphinx and sphinxfortran installed:
 ``make latexpdf`` will build the PDF version of the documentation
 (using latex and pdflatex) while ``make html`` builds the html
 version.
-
-## Distributed-memory (MPI) support ##
-
-TBD
 
 ## OpenCL Support ##
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ of how to construct a model grid and associate fields with it.
 
 The following environment variables can be set up to tune runtime options:
 
-- ALIGNMENT: Positive integer that specifies a value by which the grid contiguous
-dimension length should be divisible. If that is not the case for the selected
-problem dimensions, it will add padding elements in that dimension until the
-condition holds true. If not specified it defaults to 1.
+- `DL_ESM_ALIGNMENT`: Positive integer that specifies a value by which the grid
+contiguous dimension length should be divisible. If that is not the case for
+the selected problem dimensions, it will add padding elements in that dimension
+until the condition holds true. If not specified it defaults to 1.
 
 ## Documentation ##
 

--- a/finite_difference/example/model.f90
+++ b/finite_difference/example/model.f90
@@ -34,7 +34,7 @@ program model
   use grid_mod
   use field_mod
   use gocean_mod
-  use parallel_mod, only: get_rank
+  use parallel_mod, only: get_rank, on_master
   implicit none
   ! Total size of the model domain
   integer :: jpiglo = 4, jpjglo = 10
@@ -98,7 +98,7 @@ program model
   f_sum = field_checksum(f_field)
 
   ! All done!
-  if (get_rank() == 1) then
+  if (on_master()) then
     write(*, '(/"U checksum = ", E15.8)') u_sum
     write(*, '("V checksum = ", E15.8)') v_sum
     write(*, '("T checksum = ", E15.8)') t_sum

--- a/finite_difference/src/field_mod.f90
+++ b/finite_difference/src/field_mod.f90
@@ -181,7 +181,7 @@ contains
   function r2d_field_constructor(grid,    &
                                  grid_points, &
                                  do_tile) result(self)
-    use parallel_mod, only: go_decompose
+    use parallel_mod, only: go_decompose, get_rank
 !$    use omp_lib, only : omp_get_max_threads
     implicit none
     ! Arguments
@@ -261,15 +261,13 @@ contains
     upper_x_bound = self%grid%nx
     upper_y_bound = self%grid%ny
 
-    write(*, "('Allocating ',(A),' field with bounds: (',I1,':',I3, "// &
-             "',',I1,':',I3,')')") &
-               TRIM(ADJUSTL(fld_type)), &
-               1, upper_x_bound, 1, upper_y_bound
-    write(*,"('Internal region is:(',I1,':',I3, ',',I1,':',I3,')' )") &
-         self%internal%xstart, self%internal%xstop, &
-         self%internal%ystart, self%internal%ystop
-    write(*,"('Grid has bounds:  (',I1,':',I3, ',',I1,':',I3,')')") &
-         1, self%grid%nx, 1, self%grid%ny
+    if (get_rank() == 1) then
+        write(*, "('Allocating ',(A),' field with bounds: (',I1,':',I4, "// &
+            "',',I1,':',I4,'), internal region is (',I1,':',I4, ',',I1,':',I4,')' )") &
+            TRIM(ADJUSTL(fld_type)), 1, upper_x_bound, 1, upper_y_bound, &
+             self%internal%xstart, self%internal%xstop, &
+             self%internal%ystart, self%internal%ystop
+    endif
 
     ! Allocating with a lower bound != 1 causes problems whenever
     ! array passed as assumed-shape dummy argument because lower

--- a/finite_difference/src/field_mod.f90
+++ b/finite_difference/src/field_mod.f90
@@ -123,10 +123,6 @@ module field_mod
      module procedure r2d_free_field
   end interface
 
-  !> Info on the tile sizes
-  INTEGER, SAVE :: max_tile_width
-  INTEGER, SAVE :: max_tile_height
-
   public copy_field
   public set_field
   public field_checksum

--- a/finite_difference/src/field_mod.f90
+++ b/finite_difference/src/field_mod.f90
@@ -181,7 +181,7 @@ contains
   function r2d_field_constructor(grid,    &
                                  grid_points, &
                                  do_tile) result(self)
-    use parallel_mod, only: go_decompose, get_rank
+    use parallel_mod, only: go_decompose, on_master
 !$    use omp_lib, only : omp_get_max_threads
     implicit none
     ! Arguments
@@ -261,7 +261,7 @@ contains
     upper_x_bound = self%grid%nx
     upper_y_bound = self%grid%ny
 
-    if (get_rank() == 1) then
+    if (on_master()) then
         write(*, "('Allocating ',(A),' field with bounds: (',I1,':',I4, "// &
             "',',I1,':',I4,'), internal region is (',I1,':',I4, ',',I1,':',I4,')' )") &
             TRIM(ADJUSTL(fld_type)), 1, upper_x_bound, 1, upper_y_bound, &

--- a/finite_difference/src/global_parameters_mod.f90
+++ b/finite_difference/src/global_parameters_mod.f90
@@ -8,10 +8,6 @@ module global_parameters_mod
   ! Default length for names (eg of fields and function spaces)
   integer, parameter, public :: NAME_LEN = 1024
 
-  ! What boundary to align arrays on
-  ! AVX is 256 bit = 4 d.p. words
-  integer, parameter, public :: ALIGNMENT = 4
-
   ! Iteration spaces for kernels.
   public :: GO_CELLS, GO_EDGES, GO_VERTICES
   enum, bind(c)

--- a/finite_difference/src/gocean_mod.F90
+++ b/finite_difference/src/gocean_mod.F90
@@ -59,53 +59,97 @@ contains
   !===================================================
 
   !> Write log entry with one integer and one real arg
-  SUBROUTINE write_log_ir(fmtstr, istep, fvar)
+  SUBROUTINE write_log_ir(fmtstr, istep, fvar, all_ranks)
     use iso_fortran_env, only : output_unit ! access computing environment
+    use parallel_mod, only: get_rank
     IMPLICIT none
     CHARACTER(LEN=*), INTENT(in) :: fmtstr
     INTEGER,          INTENT(in) :: istep
     REAL(go_wp),      INTENT(in) :: fvar
+    LOGICAL, OPTIONAL            :: all_ranks
+    lOGICAL                      :: all_ranks_value
 
-    WRITE(output_unit,FMT=fmtstr) istep, fvar
+    if(present(all_ranks)) then
+        all_ranks_value = all_ranks
+    else
+        all_ranks_value = .false.
+    endif
+
+    if(all_ranks_value .or. get_rank() == 1) then
+      WRITE(output_unit,FMT=fmtstr) istep, fvar
+    endif
 
   END SUBROUTINE write_log_ir
 
   !===================================================
 
   !> Write log entry with one integer arg
-  SUBROUTINE write_log_i(fmtstr, istep)
+  SUBROUTINE write_log_i(fmtstr, istep, all_ranks)
     use iso_fortran_env, only : output_unit ! access computing environment
+    use parallel_mod, only: get_rank
     IMPLICIT none
     CHARACTER(LEN=*), INTENT(in) :: fmtstr
     INTEGER,          INTENT(in) :: istep
+    LOGICAL, OPTIONAL            :: all_ranks
+    lOGICAL                      :: all_ranks_value
 
-    WRITE(output_unit,FMT=fmtstr) istep
+    if(present(all_ranks)) then
+        all_ranks_value = all_ranks
+    else
+        all_ranks_value = .false.
+    endif
+
+    if(all_ranks_value .or. get_rank() == 1) then
+      WRITE(output_unit,FMT=fmtstr) istep
+    endif
 
   END SUBROUTINE write_log_i
 
   !===================================================
 
   !> Write log entry with one real arg
-  subroutine write_log_r(fmtstr, fvar)
+  subroutine write_log_r(fmtstr, fvar, all_ranks)
     use iso_fortran_env, only : output_unit ! access computing environment
+    use parallel_mod, only: get_rank
     implicit none
     character(len=*), intent(in) :: fmtstr
     real(go_wp),      intent(in) :: fvar
+    LOGICAL, OPTIONAL            :: all_ranks
+    lOGICAL                      :: all_ranks_value
 
-    write(output_unit,FMT=fmtstr) fvar
+    if(present(all_ranks)) then
+        all_ranks_value = all_ranks
+    else
+        all_ranks_value = .false.
+    endif
+
+    if(all_ranks_value .or. get_rank() == 1) then
+      write(output_unit,FMT=fmtstr) fvar
+    endif
 
   end subroutine write_log_r
 
   !===================================================
 
   !> Write log entry with just a string
-  subroutine write_log_a(fmtstr, msg)
+  subroutine write_log_a(fmtstr, msg, all_ranks)
     use iso_fortran_env, only : output_unit ! access computing environment
+    use parallel_mod, only: get_rank
     implicit none
     character(len=*), intent(in) :: fmtstr
     character(len=*), intent(in) :: msg
+    LOGICAL, OPTIONAL            :: all_ranks
+    lOGICAL                      :: all_ranks_value
 
-    write(output_unit,FMT=fmtstr) msg
+    if(present(all_ranks)) then
+        all_ranks_value = all_ranks
+    else
+        all_ranks_value = .false.
+    endif
+
+    if(all_ranks_value .or. get_rank() == 1) then
+      write(output_unit,FMT=fmtstr) msg
+    endif
 
   end subroutine write_log_a
 

--- a/finite_difference/src/gocean_mod.F90
+++ b/finite_difference/src/gocean_mod.F90
@@ -61,7 +61,7 @@ contains
   !> Write log entry with one integer and one real arg
   SUBROUTINE write_log_ir(fmtstr, istep, fvar, all_ranks)
     use iso_fortran_env, only : output_unit ! access computing environment
-    use parallel_mod, only: get_rank
+    use parallel_mod, only: on_master
     IMPLICIT none
     CHARACTER(LEN=*), INTENT(in) :: fmtstr
     INTEGER,          INTENT(in) :: istep
@@ -75,7 +75,7 @@ contains
         all_ranks_value = .false.
     endif
 
-    if(all_ranks_value .or. get_rank() == 1) then
+    if(all_ranks_value .or. on_master()) then
       WRITE(output_unit,FMT=fmtstr) istep, fvar
     endif
 
@@ -86,7 +86,7 @@ contains
   !> Write log entry with one integer arg
   SUBROUTINE write_log_i(fmtstr, istep, all_ranks)
     use iso_fortran_env, only : output_unit ! access computing environment
-    use parallel_mod, only: get_rank
+    use parallel_mod, only: on_master
     IMPLICIT none
     CHARACTER(LEN=*), INTENT(in) :: fmtstr
     INTEGER,          INTENT(in) :: istep
@@ -99,7 +99,7 @@ contains
         all_ranks_value = .false.
     endif
 
-    if(all_ranks_value .or. get_rank() == 1) then
+    if(all_ranks_value .or. on_master()) then
       WRITE(output_unit,FMT=fmtstr) istep
     endif
 
@@ -110,7 +110,7 @@ contains
   !> Write log entry with one real arg
   subroutine write_log_r(fmtstr, fvar, all_ranks)
     use iso_fortran_env, only : output_unit ! access computing environment
-    use parallel_mod, only: get_rank
+    use parallel_mod, only: on_master
     implicit none
     character(len=*), intent(in) :: fmtstr
     real(go_wp),      intent(in) :: fvar
@@ -123,7 +123,7 @@ contains
         all_ranks_value = .false.
     endif
 
-    if(all_ranks_value .or. get_rank() == 1) then
+    if(all_ranks_value .or. on_master()) then
       write(output_unit,FMT=fmtstr) fvar
     endif
 
@@ -134,7 +134,7 @@ contains
   !> Write log entry with just a string
   subroutine write_log_a(fmtstr, msg, all_ranks)
     use iso_fortran_env, only : output_unit ! access computing environment
-    use parallel_mod, only: get_rank
+    use parallel_mod, only: on_master
     implicit none
     character(len=*), intent(in) :: fmtstr
     character(len=*), intent(in) :: msg
@@ -147,7 +147,7 @@ contains
         all_ranks_value = .false.
     endif
 
-    if(all_ranks_value .or. get_rank() == 1) then
+    if(all_ranks_value .or. on_master()) then
       write(output_unit,FMT=fmtstr) msg
     endif
 

--- a/finite_difference/src/grid_mod.f90
+++ b/finite_difference/src/grid_mod.f90
@@ -42,10 +42,6 @@ module grid_mod
   integer, parameter :: HALO_WIDTH_X = 1
   integer, parameter :: HALO_WIDTH_Y = 1
 
-  ! What boundary to align arrays (the contiguous dimension must be
-  ! divisible by the ALIGNMENT value.)
-  integer :: ALIGNMENT = 1
-
   type, public :: grid_type
      !> The type of grid this is (e.g. Arakawa C Grid)
      integer :: name
@@ -315,7 +311,9 @@ contains
     integer :: xstart, ystart ! Start of internal region of T-pts
     integer :: xstop, ystop ! End of internal region of T-pts
     character(len=3) :: strvalue = '   '
-
+    ! What boundary to align arrays (the contiguous dimension must be
+    ! divisible by the ALIGNMENT value.)
+    integer :: ALIGNMENT = 1
 
     CALL get_environment_variable("DL_ESM_ALIGNMENT", strvalue, status=ierr(1))
     if(ierr(1) .eq. 1) then

--- a/finite_difference/src/grid_mod.f90
+++ b/finite_difference/src/grid_mod.f90
@@ -314,17 +314,22 @@ contains
     integer :: ji, jj
     integer :: xstart, ystart ! Start of internal region of T-pts
     integer :: xstop, ystop ! End of internal region of T-pts
-    character(len=2) :: strvalue = '  '
+    character(len=3) :: strvalue = '   '
 
 
     CALL get_environment_variable("ALIGNMENT", strvalue, status=ierr(1))
     if(ierr(1) .eq. 1) then
-        ! By default use ALIGNMENT 1 (no padding)
+        ! ALIGNMENET not present, by default use ALIGNMENT = 1 (no padding)
         ALIGNMENT = 1
+    else if(ierr(1) .eq. -1) then
+        ! ALIGNMENT is present but didn't fit in strvalue
+        call gocean_stop("Error: Only numbers of up to 3 digits are supported" // &
+            " in the ALIGNMENT environment variable.")
     else
-        read(strvalue,"(i1)", iostat=ierr(1)) ALIGNMENT
+        read(strvalue,"(i3)", iostat=ierr(1)) ALIGNMENT
         if(ierr(1) .ne. 0 .or. ALIGNMENT < 1) then
-            stop 'Error: Cannot convert ALIGNMENT value into a positive integer.'
+            call gocean_stop("Error: Cannot convert ALIGNMENT value ("// &
+                             strvalue // ") into a positive integer.")
         endif
     endif
     ! Extend the domain at least by unity and up to being exactly divisible
@@ -341,7 +346,7 @@ contains
         if (ALIGNMENT > 1 .and. (get_rank() == 1 .or. get_rank() == grid%decomp%nx)) then
             ! Print master rank and the first rank potentially with less nx elements
             write(*, "('Rank',I3,' contiguous dimension is',I4,' (it has'," // &
-                "I2,' padding elements to satisfy ',I2, '-wide alignment)' )") &
+                "I4,' padding elements to satisfy ',I4, '-wide alignment)' )") &
                 get_rank(), grid%nx, padding - 1, ALIGNMENT
         endif
     endif

--- a/finite_difference/src/grid_mod.f90
+++ b/finite_difference/src/grid_mod.f90
@@ -302,7 +302,7 @@ contains
   !!                  supplied if domain is all wet and has PBCs.
   subroutine grid_init(grid, dxarg, dyarg, tmask)
     use decomposition_mod, only: subdomain_type, decomposition_type
-    use parallel_mod, only: map_comms, get_rank, get_num_ranks
+    use parallel_mod, only: map_comms, get_rank, get_num_ranks, on_master
     use parallel_utils_mod, only: DIST_MEM_ENABLED
     implicit none
     type(grid_type), intent(inout) :: grid
@@ -343,7 +343,7 @@ contains
         ! This should never happen, it is a check for debugging purposes.
         call gocean_stop("Error: Could not satisfy ALIGNMENT requierements.")
     else
-        if (ALIGNMENT > 1 .and. (get_rank() == 1 .or. get_rank() == grid%decomp%nx)) then
+        if (ALIGNMENT > 1 .and. (on_master() .or. get_rank() == grid%decomp%nx)) then
             ! Print master rank and the first rank potentially with less nx elements
             write(*, "('Rank',I3,' contiguous dimension is',I4,' (it has'," // &
                 "I4,' padding elements to satisfy ',I4, '-wide alignment)' )") &

--- a/finite_difference/src/grid_mod.f90
+++ b/finite_difference/src/grid_mod.f90
@@ -317,18 +317,18 @@ contains
     character(len=3) :: strvalue = '   '
 
 
-    CALL get_environment_variable("ALIGNMENT", strvalue, status=ierr(1))
+    CALL get_environment_variable("DL_ESM_ALIGNMENT", strvalue, status=ierr(1))
     if(ierr(1) .eq. 1) then
-        ! ALIGNMENET not present, by default use ALIGNMENT = 1 (no padding)
+        ! DL_ESM_ALIGNMENT not present, by default use ALIGNMENT = 1 (no padding)
         ALIGNMENT = 1
     else if(ierr(1) .eq. -1) then
-        ! ALIGNMENT is present but didn't fit in strvalue
+        ! DL_ESM_ALIGNMENT is present but didn't fit in strvalue
         call gocean_stop("Error: Only numbers of up to 3 digits are supported" // &
-            " in the ALIGNMENT environment variable.")
+            " in the DL_ESM_ALIGNMENT environment variable.")
     else
         read(strvalue,"(i3)", iostat=ierr(1)) ALIGNMENT
         if(ierr(1) .ne. 0 .or. ALIGNMENT < 1) then
-            call gocean_stop("Error: Cannot convert ALIGNMENT value ("// &
+            call gocean_stop("Error: Cannot convert DL_ESM_ALIGNMENT value ("// &
                              strvalue // ") into a positive integer.")
         endif
     endif
@@ -341,7 +341,7 @@ contains
 
     if ( mod(grid%nx, ALIGNMENT) .ne. 0 ) then
         ! This should never happen, it is a check for debugging purposes.
-        call gocean_stop("Error: Could not satisfy ALIGNMENT requierements.")
+        call gocean_stop("Error: Could not satisfy alignment requierements.")
     else
         if (ALIGNMENT > 1 .and. (on_master() .or. get_rank() == grid%decomp%nx)) then
             ! Print master rank and the first rank potentially with less nx elements

--- a/finite_difference/src/grid_mod.f90
+++ b/finite_difference/src/grid_mod.f90
@@ -316,20 +316,16 @@ contains
     integer :: xstart, ystart ! Start of internal region of T-pts
     integer :: xstop, ystop ! End of internal region of T-pts
 
-    ! Extend the domain by unity in each dimension to allow
-    ! for staggering of variables. All fields will be
-    ! allocated with extent (nx,ny).
+    ! Extend the domain at least by unity and up to being exactly divisible
+    ! by the ALIGNMENT in the contiguous dimension to allow for staggering
+    ! of variables and an aligned access to the start of each row (by adding
+    ! extra padding in the arrays).
     mlocal = grid%subdomain%global%nx + 1
-    if( mod(mlocal, ALIGNMENT) > 0 )then
-       ! Since this is the dimension of the array and not that of
-       ! the internal region, we add two lots of 'ALIGNMENT'. This
-       ! allows us to subsequently extend the loop over the internal
-       ! region so that it too is aligned without array accesses of
-       ! the form a(i+1,j) going out of bounds.
-       grid%nx = (mlocal/ALIGNMENT + 2)*ALIGNMENT
-    else
-       grid%nx = mlocal
-    end if
+    grid%nx = mlocal + mod(mlocal, ALIGNMENT)
+    write(*,*) "nx (with padding) is", grid%nx
+
+    ! Extend the domain exactly by unity in the non-contiguous dimension to
+    ! allow for staggering of variables.
     grid%ny = grid%subdomain%global%ny + 1
 
     ! Shorthand for the definition of the internal region

--- a/finite_difference/src/parallel/parallel_utils_mod.f90
+++ b/finite_difference/src/parallel/parallel_utils_mod.f90
@@ -202,7 +202,6 @@ contains
     ! Locals
     integer :: ierr
     integer :: status(MPI_status_size)
-    integer :: astatus(MPI_status_size, nmsg)
 
     call MPI_waitany(nmsg, flags, irecv, status, ierr)
 

--- a/finite_difference/src/parallel/parallel_utils_mod.f90
+++ b/finite_difference/src/parallel/parallel_utils_mod.f90
@@ -63,7 +63,7 @@ module parallel_utils_mod
   integer, parameter :: MSG_REQUEST_NULL = MPI_REQUEST_NULL
 
   public parallel_init, parallel_finalise, parallel_abort, get_max_tag
-  public get_rank, get_num_ranks, post_receive, post_send, global_sum
+  public get_rank, get_num_ranks, post_receive, post_send, global_sum, on_master
   public msg_wait, msg_wait_all
   public MSG_UNDEFINED, MSG_REQUEST_NULL, DIST_MEM_ENABLED
 
@@ -117,6 +117,13 @@ contains
     integer :: get_rank
     get_rank = rank
   end function get_rank
+
+  !================================================
+
+  function on_master()
+    logical :: on_master
+    on_master = get_rank() == 1
+  end function on_master
 
   !================================================
 

--- a/finite_difference/src/parallel/parallel_utils_mod.f90
+++ b/finite_difference/src/parallel/parallel_utils_mod.f90
@@ -63,7 +63,7 @@ module parallel_utils_mod
   integer, parameter :: MSG_REQUEST_NULL = MPI_REQUEST_NULL
 
   public parallel_init, parallel_finalise, parallel_abort, get_max_tag
-  public get_rank, get_num_ranks, post_receive, post_send, global_sum, on_master
+  public get_rank, get_num_ranks, post_receive, post_send, global_sum
   public msg_wait, msg_wait_all
   public MSG_UNDEFINED, MSG_REQUEST_NULL, DIST_MEM_ENABLED
 
@@ -117,13 +117,6 @@ contains
     integer :: get_rank
     get_rank = rank
   end function get_rank
-
-  !================================================
-
-  function on_master()
-    logical :: on_master
-    on_master = get_rank() == 1
-  end function on_master
 
   !================================================
 

--- a/finite_difference/src/parallel/parallel_utils_mod.f90
+++ b/finite_difference/src/parallel/parallel_utils_mod.f90
@@ -83,7 +83,8 @@ contains
 
     rank = rank + 1
     if(rank == 1)then
-       write (*,*) "Number of MPI ranks: ", nranks
+       write (*,"('Number of MPI ranks:', I4)") nranks
+       write (*,*)
     end if
 
   end subroutine parallel_init

--- a/finite_difference/src/parallel/parallel_utils_stub_mod.f90
+++ b/finite_difference/src/parallel/parallel_utils_stub_mod.f90
@@ -45,7 +45,7 @@ module parallel_utils_mod
   logical, parameter :: DIST_MEM_ENABLED = .False.
 
   public parallel_init, parallel_finalise, parallel_abort
-  public get_rank, get_num_ranks, get_max_tag, on_master
+  public get_rank, get_num_ranks, get_max_tag
   public msg_wait, msg_wait_all, post_receive, post_send, global_sum
   public MSG_UNDEFINED, MSG_REQUEST_NULL, DIST_MEM_ENABLED
 
@@ -135,13 +135,6 @@ contains
     integer :: get_rank
     get_rank = rank
   end function get_rank
-
-  !================================================
-
-  function on_master()
-    logical :: on_master
-    on_master = .true.
-  end function on_master
 
   !================================================
 

--- a/finite_difference/src/parallel/parallel_utils_stub_mod.f90
+++ b/finite_difference/src/parallel/parallel_utils_stub_mod.f90
@@ -45,7 +45,7 @@ module parallel_utils_mod
   logical, parameter :: DIST_MEM_ENABLED = .False.
 
   public parallel_init, parallel_finalise, parallel_abort
-  public get_rank, get_num_ranks, get_max_tag
+  public get_rank, get_num_ranks, get_max_tag, on_master
   public msg_wait, msg_wait_all, post_receive, post_send, global_sum
   public MSG_UNDEFINED, MSG_REQUEST_NULL, DIST_MEM_ENABLED
 
@@ -135,6 +135,13 @@ contains
     integer :: get_rank
     get_rank = rank
   end function get_rank
+
+  !================================================
+
+  function on_master()
+    logical :: on_master
+    on_master = .true.
+  end function on_master
 
   !================================================
 

--- a/finite_difference/src/parallel_comms_mod.f90
+++ b/finite_difference/src/parallel_comms_mod.f90
@@ -1405,7 +1405,7 @@ contains
   integer function exchmod_alloc()
     implicit none
     ! Locals
-    integer :: ierr, ii
+    integer :: ierr
     maxExchItems = 20
     allocate(exch_flags(max_flags,MaxComm,2),   &
              exch_flags1d(MaxComm),             &

--- a/finite_difference/src/parallel_mod.f90
+++ b/finite_difference/src/parallel_mod.f90
@@ -273,7 +273,7 @@ contains
           ! Which part of the global domain the internal part of this
           ! subdomain covers
           subdomain%global%xstart = ival
-          subdomain%global%xstop = subdomain%global%xstart + width - 1
+          subdomain%global%xstop = subdomain%global%xstart + 2*hwidth + width - 1
           ! Full width of this subdomain (including halo and boundary points)
           subdomain%global%nx  = 2*hwidth + width
 
@@ -282,7 +282,7 @@ contains
           subdomain%internal%ny = height
           ! Which part of the global domain this subdomain covers
           subdomain%global%ystart = jval
-          subdomain%global%ystop = subdomain%global%ystart + height - 1
+          subdomain%global%ystop = subdomain%global%ystart + 2*hwidth + height - 1
           ! Full height of this subdomain (incl. halo and boundary points)
           subdomain%global%ny = 2*hwidth + subdomain%internal%ny
 

--- a/finite_difference/src/parallel_mod.f90
+++ b/finite_difference/src/parallel_mod.f90
@@ -31,7 +31,7 @@
 !! are independent of whether or not we are building with MPI.
 module parallel_mod
   use parallel_utils_mod, only: parallel_finalise, parallel_abort, &
-                                get_rank, get_num_ranks
+                                get_rank, get_num_ranks, on_master
   use parallel_comms_mod, only: map_comms, exchmod_alloc
   use decomposition_mod, only: decomposition_type
   implicit none
@@ -42,7 +42,7 @@ module parallel_mod
   public parallel_init, parallel_finalise, parallel_abort, go_decompose
 
   ! Export routines from other modules
-  public map_comms, get_rank, get_num_ranks
+  public map_comms, get_rank, get_num_ranks, on_master
   public decomposition_type
 
 contains
@@ -192,7 +192,7 @@ contains
        ntiley = ndomainy
     end if ! automatic determination of tiling grid
 
-    if(get_rank() == 1) then
+    if(on_master()) then
         WRITE (*,"('go_decompose: using grid of ',I3,'x',I3)") ntilex, ntiley
     endif
     decomp%nx = ntilex
@@ -221,7 +221,7 @@ contains
        iunder = 0
     end if
 
-    if(print_tiles .and. get_rank() == 1)then
+    if(print_tiles .and. on_master())then
        write(*, "('Tile width = ',I4,', tile height = ',I4)") &
                                   internal_width, internal_height
        write(*, "('iunder, junder = ', I3, 1x, I3)") iunder, junder
@@ -238,7 +238,7 @@ contains
     decomp%max_width  = 0
     decomp%max_height = 0
 
-    if(print_tiles .and. get_rank() == 1) write(*, "(/'Sub-domains:')")
+    if(print_tiles .and. on_master()) write(*, "(/'Sub-domains:')")
 
     do jj = 1, ntiley, 1
 
@@ -288,7 +288,7 @@ contains
           ! Full height of this subdomain (incl. halo and boundary points)
           subdomain%global%ny = 2*hwidth + subdomain%internal%ny
 
-          if(print_tiles .and. get_rank() == 1)then
+          if(print_tiles .and. on_master())then
              write(*, "('subdomain[',I4,'](',I4,':',I4,')(',I4,':',I4,'),"// &
                   & " interior:(',I4,':',I4,')(',I4,':',I4,') ')")      &
                   ith,                                                  &
@@ -316,7 +316,7 @@ contains
     end do
 
     ! Print tile-size statistics
-    if(print_tiles .and. get_rank() == 1)then
+    if(print_tiles .and. on_master())then
        write(*, "(/'Mean sub-domain size = ',F8.1,' pts = ',F7.1,' KB')")    &
                                    real(nvects_sum) / real(decomp%ndomains), &
                             real(8*nvects_sum) / real(decomp%ndomains*1024)

--- a/finite_difference/src/parallel_mod.f90
+++ b/finite_difference/src/parallel_mod.f90
@@ -192,7 +192,9 @@ contains
        ntiley = ndomainy
     end if ! automatic determination of tiling grid
 
-    WRITE (*,"('go_decompose: using grid of ',I3,'x',I3)") ntilex, ntiley
+    if(get_rank() == 1) then
+        WRITE (*,"('go_decompose: using grid of ',I3,'x',I3)") ntilex, ntiley
+    endif
     decomp%nx = ntilex
     decomp%ny = ntiley
 
@@ -219,7 +221,7 @@ contains
        iunder = 0
     end if
 
-    if(print_tiles)then
+    if(print_tiles .and. get_rank() == 1)then
        write(*, "('Tile width = ',I4,', tile height = ',I4)") &
                                   internal_width, internal_height
        write(*, "('iunder, junder = ', I3, 1x, I3)") iunder, junder
@@ -236,7 +238,7 @@ contains
     decomp%max_width  = 0
     decomp%max_height = 0
 
-    if(print_tiles) write(*, "(/'Sub-domains:')")
+    if(print_tiles .and. get_rank() == 1) write(*, "(/'Sub-domains:')")
 
     do jj = 1, ntiley, 1
 
@@ -273,7 +275,7 @@ contains
           ! Which part of the global domain the internal part of this
           ! subdomain covers
           subdomain%global%xstart = ival
-          subdomain%global%xstop = subdomain%global%xstart + 2*hwidth + width - 1
+          subdomain%global%xstop = subdomain%global%xstart + width - 1
           ! Full width of this subdomain (including halo and boundary points)
           subdomain%global%nx  = 2*hwidth + width
 
@@ -282,11 +284,11 @@ contains
           subdomain%internal%ny = height
           ! Which part of the global domain this subdomain covers
           subdomain%global%ystart = jval
-          subdomain%global%ystop = subdomain%global%ystart + 2*hwidth + height - 1
+          subdomain%global%ystop = subdomain%global%ystart + height - 1
           ! Full height of this subdomain (incl. halo and boundary points)
           subdomain%global%ny = 2*hwidth + subdomain%internal%ny
 
-          if(print_tiles)then
+          if(print_tiles .and. get_rank() == 1)then
              write(*, "('subdomain[',I4,'](',I4,':',I4,')(',I4,':',I4,'),"// &
                   & " interior:(',I4,':',I4,')(',I4,':',I4,') ')")      &
                   ith,                                                  &
@@ -314,7 +316,7 @@ contains
     end do
 
     ! Print tile-size statistics
-    if(print_tiles)then
+    if(print_tiles .and. get_rank() == 1)then
        write(*, "(/'Mean sub-domain size = ',F8.1,' pts = ',F7.1,' KB')")    &
                                    real(nvects_sum) / real(decomp%ndomains), &
                             real(8*nvects_sum) / real(decomp%ndomains*1024)

--- a/finite_difference/src/parallel_mod.f90
+++ b/finite_difference/src/parallel_mod.f90
@@ -31,7 +31,7 @@
 !! are independent of whether or not we are building with MPI.
 module parallel_mod
   use parallel_utils_mod, only: parallel_finalise, parallel_abort, &
-                                get_rank, get_num_ranks, on_master
+                                get_rank, get_num_ranks
   use parallel_comms_mod, only: map_comms, exchmod_alloc
   use decomposition_mod, only: decomposition_type
   implicit none
@@ -40,9 +40,10 @@ module parallel_mod
 
   ! The public routines implemented in this module
   public parallel_init, parallel_finalise, parallel_abort, go_decompose
+  public on_master
 
   ! Export routines from other modules
-  public map_comms, get_rank, get_num_ranks, on_master
+  public map_comms, get_rank, get_num_ranks
   public decomposition_type
 
 contains
@@ -329,5 +330,13 @@ contains
     end if
 
   end function go_decompose
+
+
+  !> Returns True if this is the master process in the parallel execution
+  !! environment, otherwise returns False.
+  function on_master()
+    logical :: on_master
+    on_master = get_rank() == 1
+  end function on_master
 
 end module parallel_mod


### PR DESCRIPTION
As described in #45 , the ALIGNMENT is now configureable with an environment variable. I also brought FortCL to master and compacted and avoided printing duplicate lines in distributed memory execution outputs.

An example with size 511 (which requieres different padding in different tiles) now looks:
```
laptop$ ALIGNMENT=4 mpirun -n 4 ./nemolite2d.exe
Number of MPI ranks:   4

go_decompose: using grid of   2x  2
Tile width =  255, tile height =  255
iunder, junder =   1   1

Sub-domains:
subdomain[   1](   1: 256)(   1: 256), interior:(   2: 257)(   2: 257)
subdomain[   2]( 257: 511)(   1: 256), interior:(   2: 256)(   2: 257)
subdomain[   3](   1: 256)( 257: 511), interior:(   2: 257)(   2: 256)
subdomain[   4]( 257: 511)( 257: 511), interior:(   2: 256)(   2: 256)

Mean sub-domain size =  65280.2 pts =   510.0 KB
Min,max sub-domain size (pts) =  65025, 65536
Domain load imbalance (%) =  0.79
Max sub-domain dims are  258x 258

Rank  1 contiguous dimension is 260 (it has 1 padding elements to satisfy  4-wide alignment)
Rank  2 contiguous dimension is 260 (it has 2 padding elements to satisfy  4-wide alignment)
Allocating C-U field with bounds: (1: 260,1: 259), internal region is (2: 257,2: 257)
Allocating C-V field with bounds: (1: 260,1: 259), internal region is (2: 257,2: 257)
Allocating C-T field with bounds: (1: 260,1: 259), internal region is (2: 257,2: 257)
Allocating C-U field with bounds: (1: 260,1: 259), internal region is (2: 257,2: 257)
Allocating C-V field with bounds: (1: 260,1: 259), internal region is (2: 257,2: 257)
Allocating C-T field with bounds: (1: 260,1: 259), internal region is (2: 257,2: 257)
Allocating C-U field with bounds: (1: 260,1: 259), internal region is (2: 257,2: 257)
Allocating C-V field with bounds: (1: 260,1: 259), internal region is (2: 257,2: 257)
Allocating C-T field with bounds: (1: 260,1: 259), internal region is (2: 257,2: 257)
Allocating C-U field with bounds: (1: 260,1: 259), internal region is (2: 257,2: 257)
Allocating C-V field with bounds: (1: 260,1: 259), internal region is (2: 257,2: 257)
Allocating C-U field with bounds: (1: 260,1: 259), internal region is (2: 257,2: 257)
Allocating C-V field with bounds: (1: 260,1: 259), internal region is (2: 257,2: 257)
```