### PR TITLE
Add finer control field methods to read and write halos from accelerated devices

### DIFF
--- a/.github/workflows/makefile-test.yml
+++ b/.github/workflows/makefile-test.yml
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # BSD 3-Clause License
 #
-# Copyright (c) 2019, Science and Technology Facilities Council
+# Copyright (c) 2021, Science and Technology Facilities Council.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -31,15 +31,33 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 # -----------------------------------------------------------------------------
+# Author S. Siso, STFC Daresbury Lab
+#
+# This workflow will compile dl_esm_inf and check that the various examples
+# and tests compile and run.
 
-language: c
-sudo: required
-before_install:
-  - sudo apt-get install gfortran valgrind libopenmpi-dev openmpi-bin
+name: DL_ESM_INF CI tests
 
-script:
-  - . compiler_setup/gnu.sh
-  - make -C finite_difference/example serial-test
-  - make -C finite_difference/example parallel-test
-  - make -C finite_difference/tests/dist_mem
-  - make -C finite_difference/tests/device_computation
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: >
+          sudo apt-get install build-essential gfortran valgrind libopenmpi-dev
+          openmpi-bin
+    - name: Run tests
+      run: >
+        source compiler_setup/gnu.sh && export MPIRUN="mpirun --oversubscribe" &&
+        make -C finite_difference/example serial-test &&
+        make -C finite_difference/example parallel-test &&
+        make -C finite_difference/tests/dist_mem &&
+        make -C finite_difference/tests/device_computation

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.a
 *.exe
 gnu_opt_report.txt
+*.optrpt

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,4 @@ script:
   - make -C finite_difference/example serial-test
   - make -C finite_difference/example parallel-test
   - make -C finite_difference/tests/dist_mem
+  - make -C finite_difference/tests/device_computation

--- a/finite_difference/src/Makefile
+++ b/finite_difference/src/Makefile
@@ -95,7 +95,7 @@ install:
 	${MAKE} -C .. install
 
 clean:
-	rm -f *.o *.mod *.a
+	rm -f *.o *.mod *.a *.optrpt
 
 distclean: clean
 

--- a/finite_difference/src/field_mod.f90
+++ b/finite_difference/src/field_mod.f90
@@ -71,13 +71,8 @@ module field_mod
   !
   abstract interface
     subroutine read_from_device_c_interface(from, to, offset, nx, ny, stride_gap)
-        ! Disable argument checking for Intel compiler to allow it to pass a
-        ! C_LOC() pointer into a C_INTPTR_T. This disables the checking that
-        ! the pointer addresses are represented by the integers of the same
-        ! number of bits.
-        !DEC$ ATTRIBUTES NO_ARG_CHECK :: to
-        use iso_c_binding, only: c_intptr_t, c_int, c_ptr
-        integer(c_intptr_t), intent(in), value :: from
+        use iso_c_binding, only: c_ptr, c_int
+        type(c_ptr), intent(in), value :: from
         type(c_ptr), intent(in), value :: to
         integer(c_int), intent(in), value :: offset, nx, ny, stride_gap
     end subroutine read_from_device_c_interface
@@ -85,9 +80,9 @@ module field_mod
 
   abstract interface
     subroutine read_from_device_f_interface(from, to, offset, nx, ny, stride_gap)
-        use iso_c_binding, only: c_intptr_t, c_int
+        use iso_c_binding, only: c_ptr
         use kind_params_mod, only: go_wp
-        integer(c_intptr_t), intent(in) :: from
+        type(c_ptr), intent(in) :: from
         real(go_wp), dimension(:,:), intent(inout) :: to
         integer, intent(in) :: offset, nx, ny, stride_gap
     end subroutine read_from_device_f_interface
@@ -95,24 +90,19 @@ module field_mod
 
   abstract interface
     subroutine write_to_device_c_interface(from, to, offset, nx, ny, stride_gap)
-        ! Disable argument checking for Intel compiler to allow it to pass a
-        ! C_LOC() pointer into a C_INTPTR_T. This disables the checking that
-        ! the pointer addresses are represented by the integers of the same
-        ! number of bits.
-        !DEC$ ATTRIBUTES NO_ARG_CHECK :: to
-        use iso_c_binding, only: c_intptr_t, c_int, c_ptr
+        use iso_c_binding, only: c_int, c_ptr
         type(c_ptr), intent(in), value :: from
-        integer(c_intptr_t), intent(in), value :: to
+        type(c_ptr), intent(in), value :: to
         integer(c_int), intent(in), value :: offset, nx, ny, stride_gap
     end subroutine write_to_device_c_interface
   end interface
 
   abstract interface
     subroutine write_to_device_f_interface(from, to, offset, nx, ny, stride_gap)
-        use iso_c_binding, only: c_intptr_t, c_int
+        use iso_c_binding, only: c_ptr
         use kind_params_mod, only: go_wp
         real(go_wp), dimension(:,:), intent(in) :: from
-        integer(c_intptr_t), intent(in) :: to !,value?
+        type(c_ptr), intent(in) :: to
         integer, intent(in) :: offset, nx, ny, stride_gap
     end subroutine write_to_device_f_interface
   end interface
@@ -163,7 +153,7 @@ module field_mod
      !> Pointer to corresponding buffer on remote device (if any).
      !! This requires variables that are declared to be of this type
      !! have the 'target' attribute.
-     integer(c_intptr_t) :: device_ptr
+     type(c_ptr) :: device_ptr
    contains
      !> Setter for the data associated with this field
      procedure, pass :: set_data
@@ -292,6 +282,8 @@ contains
     !> The function pointers are initialized with NULL
     nullify(self%read_from_device_c)
     nullify(self%read_from_device_f)
+    nullify(self%write_to_device_c)
+    nullify(self%write_to_device_f)
 
     ! Set-up the limits of the 'internal' region of this field
     !

--- a/finite_difference/src/field_mod.f90
+++ b/finite_difference/src/field_mod.f90
@@ -512,11 +512,9 @@ contains
 
 
   function get_data(self) result(dptr)
-    !> Getter for the data associated with a field.
-    !
-    ! If the data is on a device, it ensures that the host copy is up-to-date
-    ! with that on any accelerator device.
-    !
+    !> Getter for the data associated with a field. If the data is on a
+    ! device it ensures that the host copy is up-to-date with that on
+    ! any accelerator device.
     class(r2d_field), target :: self
     real(go_wp), dimension(:,:), pointer :: dptr
 
@@ -531,17 +529,16 @@ contains
 
   function set_data(self, array) result(flag)
     !> Setter for the data associated with a field. If data is on a
-    !! remote OpenACC device then the device copy is updated too.
+    !! remote accelerator device then the device copy is updated too.
     implicit none
     class(r2d_field) :: self
     integer :: flag
     real(go_wp), dimension(:,:) :: array
     self%data = array
-    if(self%data_on_device)then
-       !$acc update device(self%data)
-       !> \TODO #29 update data on OpenCL device. Requires that FortCL
-       !! be extended.
-    end if
+
+    ! Synchronise the whole array
+    call self%write_to_device()
+
     flag = 0
   end function set_data
 

--- a/finite_difference/src/field_mod.f90
+++ b/finite_difference/src/field_mod.f90
@@ -388,7 +388,7 @@ contains
   subroutine read_from_device(self, startx, starty, nx, ny, blocking)
     !> Update the host data with the device data.
     ! The optional startx, starty, nx and ny parameters can be provided to
-    ! read to the device just from a sub-region of the field.
+    ! read just from a sub-region of the field.
     ! The blocking optional parameter specifies if the data transfer should
     ! have finished on the return from this routine.
 
@@ -448,7 +448,7 @@ contains
   subroutine write_to_device(self, startx, starty, nx, ny, blocking)
     !> Update the device data with host data.
     ! The optional startx, starty, nx and ny parameters can be provided to
-    ! write to the device just a sub-region of the field.
+    ! write just a sub-region of the field to the device.
     ! The blocking optional parameter specifies if the data transfer should
     ! have finished on the return from this routine.
 
@@ -1205,6 +1205,8 @@ contains
   !! The depth value is currently ignored and hardwired to 1: the device
   !! synchonization and the halo_exchange communicators need to be updated
   !! with the provided depth.
+  !!
+  !! TODO #58: This method could benefit from an asynchronous execution model.
   subroutine halo_exchange(self, depth)
     use parallel_comms_mod, only: Iplus, Iminus, Jplus, Jminus, NONE, &
          exchange_generic
@@ -1241,8 +1243,6 @@ contains
 
     ! Get location and dimension to read data for the given communicator
     if (isrcsend(comm) > 0) then
-        !write(*,*) "Read halo from device: I=", isrcsend(comm), ", J=", &
-        !    jsrcsend(comm), ", NX=", nxsend(comm), ", NY=", nysend(comm)
         call self%read_from_device(isrcsend(comm), jsrcsend(comm), &
             nxsend(comm), nysend(comm), blocking)
     endif
@@ -1257,8 +1257,6 @@ contains
 
     ! Get location and dimension to write data for the given communicator
     if (idesrecv(comm) > 0) then
-        !write(*,*) "Write halo to device: I=", idesrecv(comm), ", J=", &
-        !    jdesrecv(comm), ", NX=", nxrecv(comm), ", NY=", nyrecv(comm)
         call self%write_to_device(idesrecv(comm), jdesrecv(comm), &
             nxrecv(comm), nyrecv(comm), blocking)
     endif

--- a/finite_difference/src/field_mod.f90
+++ b/finite_difference/src/field_mod.f90
@@ -451,7 +451,10 @@ contains
   end subroutine read_from_device
 
   subroutine write_to_device(self, startx, starty, nx, ny)
-    !> Update the host data with
+    !> Update the device data with host data.
+    ! The optional startx, starty, nx and ny parameters can be provided to
+    ! write to the device just a slice of the field.
+
     class(r2d_field), target :: self
     integer, optional, intent(in) :: startx, starty, nx, ny
     integer :: local_startx, local_starty, local_nx, local_ny, offset, gap
@@ -1242,7 +1245,7 @@ contains
     class(r2d_field), target, intent(inout) :: self
     integer, intent(in) :: comm
 
-    ! Get location and dimension to read for the given communicator
+    ! Get location and dimension to read data for the given communicator
     if (isrcsend(comm) > 0) then
         !write(*,*) "Read halo from device: I=", isrcsend(comm), ", J=", &
         !    jsrcsend(comm), ", NX=", nxsend(comm), ", NY=", nysend(comm)
@@ -1257,7 +1260,7 @@ contains
     class(r2d_field), target, intent(inout) :: self
     integer, intent(in) :: comm
 
-    ! Get location and dimension to read for the given communicator
+    ! Get location and dimension to write data for the given communicator
     if (idesrecv(comm) > 0) then
         !write(*,*) "Write halo to device: I=", idesrecv(comm), ", J=", &
         !    jdesrecv(comm), ", NX=", nxrecv(comm), ", NY=", nyrecv(comm)

--- a/finite_difference/src/field_mod.f90
+++ b/finite_difference/src/field_mod.f90
@@ -30,7 +30,6 @@
 !> Module for describing all aspects of a field (which exists on some
 !! grid).
 module field_mod
-  use iso_c_binding, only: c_intptr_t
   use kind_params_mod
   use region_mod
   use halo_mod
@@ -83,7 +82,7 @@ module field_mod
         use iso_c_binding, only: c_ptr
         use kind_params_mod, only: go_wp
         type(c_ptr), intent(in) :: from
-        real(go_wp), dimension(:,:), intent(inout) :: to
+        real(go_wp), dimension(:,:), target, intent(inout) :: to
         integer, intent(in) :: offset, nx, ny, stride_gap
     end subroutine read_from_device_f_interface
   end interface
@@ -101,7 +100,7 @@ module field_mod
     subroutine write_to_device_f_interface(from, to, offset, nx, ny, stride_gap)
         use iso_c_binding, only: c_ptr
         use kind_params_mod, only: go_wp
-        real(go_wp), dimension(:,:), intent(in) :: from
+        real(go_wp), dimension(:,:), target, intent(in) :: from
         type(c_ptr), intent(in) :: to
         integer, intent(in) :: offset, nx, ny, stride_gap
     end subroutine write_to_device_f_interface
@@ -505,7 +504,7 @@ contains
              offset, local_nx, local_ny, gap)
         else
           call gocean_stop("ERROR: Data is on a device but no instructions " // &
-              "about how to push new data have been provided.")
+              "about how to write new data have been provided.")
        endif
     endif
   end subroutine write_to_device

--- a/finite_difference/tests/device_computation/Makefile
+++ b/finite_difference/tests/device_computation/Makefile
@@ -61,8 +61,8 @@ test_device_io.exe: inf_lib test_device_io.o
 	${F90} -o $@ ${LDFLAGS} test_device_io.o ${INF_LIB}
 
 %.o: %.[fF]90
-	$(F90) $(F90FLAGS) ${OMPFLAGS} -I${INF_INC} -c $<
+	$(F90) $(F90FLAGS) -I${INF_INC} -c $<
 
 clean: 
 	${MAKE} -C ${INF_DIR} clean
-	rm -f *.o *.mod *.MOD *~ *.exe gnu_opt_report.txt
+	rm -f *.o *.mod *.MOD *~ *.exe gnu_opt_report.txt *.optrpt

--- a/finite_difference/tests/device_computation/Makefile
+++ b/finite_difference/tests/device_computation/Makefile
@@ -1,0 +1,68 @@
+#------------------------------------------------------------------------------
+# BSD 2-Clause License
+# 
+# Copyright (c) 2021, Science and Technology Facilities Council.
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# 
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#------------------------------------------------------------------------------
+# Author: S. Siso, STFC Daresbury Laboratory
+
+# Makefile for dist_mem tests for the dl_esm_inf finite difference library.
+#
+# This Makefile picks up the compiler to use plus any associated flags from
+# environment variables. e.g. to use gfortran:
+# 
+# export F90=mpif90
+# export MPIRUN=mpirun
+# export F90FLAGS="-O3"
+# export AR=ar
+# make
+#
+all: tests
+
+# Location of the dl_esm_inf library
+INF_DIR=../..
+INF_INC = ${INF_DIR}/src
+INF_LIB = ${INF_DIR}/src/lib_fd.a
+
+.PHONY: test_device_io inf_lib clean
+
+# Compile and run tests. This is a very basic target.
+tests: test_device_io
+
+test_device_io: inf_lib test_device_io.exe
+	./test_device_io.exe
+
+inf_lib:
+	${MAKE} -C ${INF_DIR} F90="${F90}" fd_lib
+
+# Normal targets
+test_device_io.exe: inf_lib test_device_io.o
+	${F90} -o $@ ${LDFLAGS} test_device_io.o ${INF_LIB}
+
+%.o: %.[fF]90
+	$(F90) $(F90FLAGS) ${OMPFLAGS} -I${INF_INC} -c $<
+
+clean: 
+	${MAKE} -C ${INF_DIR} clean
+	rm -f *.o *.mod *.MOD *~ *.exe gnu_opt_report.txt

--- a/finite_difference/tests/device_computation/test_device_io.f90
+++ b/finite_difference/tests/device_computation/test_device_io.f90
@@ -27,7 +27,7 @@
 !------------------------------------------------------------------------------
 ! Author: S. Siso, STFC Daresbury Laboratory
 
-! Mock device implementation using separate host memory
+! Mock device implementation using separate 1D host memory
 module virtual_device
     use field_mod
     use kind_params_mod, only: go_wp
@@ -62,7 +62,7 @@ contains
 
         do i = starty, starty + ny - 1
             ! Copy next contiguous chunk
-            to(startx:startx+nx, i) = device_memory(next_offset:next_offset+nx)
+            to(startx:startx+nx-1, i) = device_memory(next_offset:next_offset+nx-1)
             next_offset = next_offset + size(to,1)
         enddo
 
@@ -83,7 +83,7 @@ contains
 
         do i = starty, starty + ny - 1
             ! Copy next contiguous chunk
-            device_memory(next_offset:next_offset+nx) = from(startx:startx+nx, i)
+            device_memory(next_offset:next_offset+nx-1) = from(startx:startx+nx-1, i)
             next_offset = next_offset + size(from,1)
         enddo
 

--- a/finite_difference/tests/device_computation/test_device_io.f90
+++ b/finite_difference/tests/device_computation/test_device_io.f90
@@ -47,14 +47,15 @@ contains
         field%write_to_device_f => write_to_device_impl
     end subroutine
 
-    subroutine read_from_device_impl(from, to, startx, starty, nx, ny)
+    subroutine read_from_device_impl(from, to, startx, starty, nx, ny, blocking)
         type(c_ptr), intent(in) :: from
         real(go_wp), dimension(:,:), target, intent(inout) :: to
         integer, intent(in) :: startx, starty, nx, ny
+        logical, intent(in) :: blocking
         real(go_wp), dimension(:), pointer :: device_memory
-        integer :: next_offset, gap, i
+        integer :: next_offset, i
 
-        write(*, *) "Read operation", startx, starty, nx, ny
+        write(*, *) "Read operation", startx, starty, nx, ny, blocking
         call C_F_POINTER(from, device_memory, [size(to,1) * size(to,2)])
 
         next_offset = ((starty - 1) * size(to,1) + (startx-1)) + 1
@@ -67,14 +68,15 @@ contains
 
     end subroutine read_from_device_impl
 
-    subroutine write_to_device_impl(from, to, startx, starty, nx, ny)
+    subroutine write_to_device_impl(from, to, startx, starty, nx, ny, blocking)
         real(go_wp), dimension(:,:), target, intent(in) :: from
         type(c_ptr), intent(in) :: to
         integer, intent(in) ::  startx, starty, nx, ny
+        logical, intent(in) :: blocking
         real(go_wp), dimension(:), pointer :: device_memory
-        integer :: i, next_offset, gap
+        integer :: i, next_offset
 
-        write(*, *) "Write operation", startx, starty, nx, ny
+        write(*, *) "Write operation", startx, starty, nx, ny, blocking
         call C_F_POINTER(to, device_memory, [size(from,1) * size(from,2)])
 
         next_offset = ((starty - 1) * size(from,1) + (startx-1)) + 1

--- a/finite_difference/tests/device_computation/test_device_io.f90
+++ b/finite_difference/tests/device_computation/test_device_io.f90
@@ -31,7 +31,7 @@
 module virtual_device
     use field_mod
     use kind_params_mod, only: go_wp
-    use iso_c_binding
+    use iso_c_binding, only: c_loc, c_ptr, c_f_pointer
     implicit none
 
 contains

--- a/finite_difference/tests/device_computation/test_device_io.f90
+++ b/finite_difference/tests/device_computation/test_device_io.f90
@@ -49,7 +49,7 @@ contains
 
     subroutine read_from_device_impl(from, to, offset, nx, ny, stride_gap)
         type(c_ptr), intent(in) :: from
-        real(go_wp), dimension(:,:), intent(inout) :: to
+        real(go_wp), dimension(:,:), target, intent(inout) :: to
         integer, intent(in) :: offset, nx, ny, stride_gap
         real(go_wp), dimension(:), pointer :: device_memory
         integer :: i, startx, starty, next_offset
@@ -70,7 +70,7 @@ contains
     end subroutine read_from_device_impl
 
     subroutine write_to_device_impl(from, to, offset, nx, ny, stride_gap)
-        real(go_wp), dimension(:,:), intent(in) :: from
+        real(go_wp), dimension(:,:), target, intent(in) :: from
         type(c_ptr), intent(in) :: to
         integer, intent(in) :: offset, nx, ny, stride_gap
         real(go_wp), dimension(:), pointer :: device_memory

--- a/finite_difference/tests/device_computation/test_device_io.f90
+++ b/finite_difference/tests/device_computation/test_device_io.f90
@@ -1,0 +1,133 @@
+!------------------------------------------------------------------------------
+! BSD 2-Clause License
+! 
+! Copyright (c) 2021, Science and Technology Facilities Council
+! All rights reserved.
+! 
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions are met:
+! 
+! * Redistributions of source code must retain the above copyright notice, this
+!   list of conditions and the following disclaimer.
+! 
+! * Redistributions in binary form must reproduce the above copyright notice,
+!   this list of conditions and the following disclaimer in the documentation
+!   and/or other materials provided with the distribution.
+! 
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+! FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+! DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+! SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+! OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!------------------------------------------------------------------------------
+! Author: S. Siso, STFC Daresbury Laboratory
+
+!> Tests for the field read and write to device functionality.
+program test_device_io
+    use kind_params_mod
+    use parallel_mod
+    use grid_mod
+    use field_mod
+    use gocean_mod
+    implicit none
+    ! Total size of the model domain
+    integer :: jpiglo = 5, jpjglo = 5
+    ! (Uniform) grid resolution
+    real(go_wp) :: dx = 1.0
+    real(go_wp) :: dy = 1.0
+    !> The grid on which our fields are defined
+    type(grid_type), target :: model_grid
+    !> An example field
+    type(r2d_field) :: test_field
+    ! Local definition of the T-point mask which defines whether T points are
+    ! wet (1), dry (0) or outside (-1) the simulation domain.
+    integer, allocatable :: tmask(:,:)
+    integer :: ierr
+    integer :: i
+
+    call gocean_initialise()
+
+    !> Create our grid object
+    model_grid = grid_type(GO_ARAKAWA_C, &
+                           (/GO_BC_EXTERNAL,GO_BC_EXTERNAL,GO_BC_NONE/), &
+                           GO_OFFSET_NE)
+
+    !> Generate a domain decomposition. This automatically uses the number
+    !! of MPI ranks available.
+    call model_grid%decompose(jpiglo, jpjglo)
+
+    !> Create a T-point mask describing the (local) domain
+    allocate(tmask(model_grid%subdomain%global%nx,  &
+             model_grid%subdomain%global%ny), Stat=ierr)
+    if(ierr /= 0)then
+        call gocean_stop('Failed to allocate T-mask')
+    end if
+    ! To keep things simple we set all points to be wet and within the domain
+    tmask = 1
+
+    !> Complete the initialisation of the grid using the T-mask and
+    !! grid resolution
+    call grid_init(model_grid, dx, dy, tmask)
+
+    !> Create fields on U,V,T,F-points of the grid
+    test_field = r2d_field(model_grid, GO_U_POINTS)
+    call init_device_memory(test_field)
+
+    test_field%data = 1
+    call test_field%write_to_device()
+
+    do i=1, 8
+    write(*, "(10f5.1)") test_field%data(i, :)
+    enddo
+
+    call gocean_finalise()
+
+contains
+
+    ! Mock device implementation using separate host memory
+    subroutine init_device_memory(field)
+        type(r2d_field), intent(inout) :: field
+        real, dimension(:), allocatable, target :: device_memory
+
+        allocate(device_memory(size(field%data,1) * size(field%data,2)))
+        field%device_ptr = C_LOC(device_memory)
+        field%read_from_device_f => read_from_device_impl
+        field%write_to_device_f => write_to_device_impl
+
+    end subroutine
+
+    subroutine read_from_device_impl(from, to, offset, nx, ny, stride_gap)
+        use iso_c_binding, only: c_intptr_t, c_int
+        use kind_params_mod, only: go_wp
+        integer(c_intptr_t), intent(in) :: from
+        real(go_wp), dimension(:,:), intent(inout) :: to
+        integer, intent(in) :: offset, nx, ny, stride_gap
+
+    end subroutine read_from_device_impl
+
+    subroutine write_to_device_impl(from, to, offset, nx, ny, stride_gap)
+        use iso_c_binding, only: c_intptr_t, c_int
+        use kind_params_mod, only: go_wp
+        real(go_wp), dimension(:,:), intent(in) :: from
+        integer(c_intptr_t), intent(in) :: to
+        integer, intent(in) :: offset, nx, ny, stride_gap
+        real, dimension(:), pointer :: device_memory
+        integer :: i, startx, starty
+
+        call C_F_POINTER(to, device_memory)
+        
+        startx = 1
+        starty = 1
+
+        do i = starty, ny
+            device_memory(offset+startx:offset+startx+nx) = from(i,startx:startx+nx) 
+        enddo
+
+    end subroutine write_to_device_impl
+
+end program test_device_io


### PR DESCRIPTION
Closes #53 by adding parameters to the read_from/write_to_device methods. The halos in the generic exchange are now passed using this finer-grain data selection.

Also:
- Closes #29 : Adds write_to_device methods and fixes set_data().
- Added a new test to check the device acceleration functionality (it is not exhaustive yet but at least it starts providing some examples and guarantees)
- Switched to GitHub Actions
- Switched device pointers to `type(c_ptr)` instead of `integer(c_intptr_t)`. The reason is that the later is exclusive to how OpenCL works (and causes some compiler issues). The c_ptr is more generic and fits better with SYCL and Kokkos.